### PR TITLE
Handle limited area

### DIFF
--- a/jcclass/JC_classification.py
+++ b/jcclass/JC_classification.py
@@ -59,24 +59,11 @@ def JC_classification(filename):
     print('Checking latitude coordinates values...')
     mslp = JC_functions.checking_lat_coords(mslp)
 
-    #Computing factors based on grid size
-    dif_lon = float((mslp.lon[1]-mslp.lon[0]))
-    dif_lat = float((mslp.lat[1]-mslp.lat[0]))
-
-    factor_lat = float(np.abs(1/dif_lat))
-    factor_lon = float(np.abs(1/dif_lon))
-    f_lat1 = int(10*factor_lat)
-    f_lat2 = int(-10*factor_lat)
-    
-    f_lon1 = int(15*factor_lon)
-    f_lon2 = int(-15*factor_lon)
     #Checking if the MSLP data covers the whole world
     answer_globe = JC_functions.is_world(mslp)
-    if answer_globe == True:
-        psl_area=mslp[:,f_lat1:f_lat2, :] 
-    elif answer_globe == False:
-        psl_area=mslp[:,f_lat1:f_lat2, f_lon1:f_lon2]
-        
+    min_lat, max_lat = (-80.0, 80.0)
+    psl_area = mslp.where((mslp.lat >= min_lat) & (mslp.lat <= max_lat), drop=True)
+
     lat = psl_area.lat
     lon = psl_area.lon
     time = psl_area.time.values

--- a/test_case_limited_area.py
+++ b/test_case_limited_area.py
@@ -1,0 +1,26 @@
+import xarray as xr
+from jcclass import jc
+
+min_lon, max_lon, min_lat, max_lat = (4, 32, 54, 72)  # nordic
+
+da = xr.open_dataset("sample_data/era5_hourly_highres.nc")
+
+print(da.coords)
+
+# Subset on limited area 'nordic'
+da_subset = da.where(
+    (da.longitude >= min_lon) & (da.longitude <= max_lon) & (da.latitude >= min_lat) & (da.latitude <= max_lat),
+    drop=True,
+)
+
+print(da_subset.coords)
+
+# Original test data
+jc_res = jc(da)
+cts_27 = jc_res.classification()
+cts_11 = jc_res.eleven_cts(cts_27)
+
+# Limited area 'nordic' test data
+jc_res_nordic = jc(da_subset)
+cts_27 = jc_res_nordic.classification()
+cts_11 = jc_res_nordic.eleven_cts(cts_27)


### PR DESCRIPTION
Hi, 

Thank you for sharing your work. I found what I think is a bug but I would need some input in order to understand if my solution is sufficient. **Also, do not accept the PR before the test script is removed.**

When trying to run classification on a limited area I found some code which by "constant index" slicing simply removed all my data points.

L78-red: `psl_area=mslp[:,f_lat1:f_lat2, f_lon1:f_lon2]`

For latitude I understand wanting to remove the poles, but I could not understand the longitude slicing for when is_world==False.

When running with sample data the longtude slicing caused unchanged sample data to end up in longitude range [-165, 165]. **This is what I do not understand. Is it correct and neccessary?**. It seems strange to me to remove longitude values.

Since this repo does not have any tests I added a test script in a separate commit to show what I want to be able to run.  I did confirm that 

`mslp[:,f_lat1:f_lat2, :].equals(mslp.where((mslp.lat >= min_lat) & (mslp.lat <= max_lat), drop=True))`

for the sample data when the old code was not removed, to ensure that nothing did change for the is_world==True case.

